### PR TITLE
fix(schema): align Specials Offer schema with Schema 2.0 mapping

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,23 @@
 # Change log
 
+## [2.2 — Schema] - 2026-07-29
+
+### Fixed
+- Schema: `@type` simplified from `array( 'Offer' )` to a plain `'Offer'` string.
+- Schema: `@id` updated from `#special` to `#/schema/offer/{id}` to avoid collisions on pages with multiple specials.
+- Schema: `name` now uses `get_the_title( $post->ID )` instead of `$post->post_title` directly.
+- Schema: `description` now uses `\lsx\schema\Helpers::strip_to_text()` on `apply_filters( 'the_content', … )` instead of a bare `wp_strip_all_tags()` on raw post content.
+- Schema: meta queries changed from `get_the_ID()` to `$this->context->id` for consistency.
+- Schema: duplicate `itemOffered` keys (tours and accommodation were silently overwriting each other) replaced with a new `add_items_offered()` method that merges both into a single value; tours typed as `TouristTrip`, accommodation as `LodgingBusiness`.
+- Schema: duplicate `priceValidUntil` assignment removed.
+- Schema: availability and price-validity dates now formatted as ISO 8601 via a new `add_availability()` helper that calls `\lsx\schema\Helpers::format_iso_date()`; fields are omitted when the date is empty.
+- Schema: `get_price()` refactored — currency now resolved via `\lsx\schema\Helpers::get_currency()` instead of inline `tour_operator()` option lookup; price value normalised via `\lsx\schema\Helpers::normalise_price()`.
+- Schema: `PriceSpecification` key corrected to lowercase `priceSpecification`; now outputs a properly typed `PriceSpecification` object with `@type`, `price`, `priceCurrency`, and `unitText` instead of a bare label string.
+
+### Added
+- Schema: new `add_availability()` helper that reads a raw CMB2 date meta value, formats it as ISO 8601, and conditionally sets the given schema property.
+- Schema: new `add_items_offered()` method that merges related tour and accommodation post IDs into a single `itemOffered` value without overwriting.
+
 ## [[2.1]](https://github.com/lightspeeddevelopment/to-specials/releases/tag/2.1) - 2025-01-13
 
 ### Description

--- a/classes/class-to-specials-schema.php
+++ b/classes/class-to-specials-schema.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * The Trip Schema for Tours
+ * The Offer Schema for Specials
  *
  * @package tour-operator
  */
 
 /**
- * Returns schema Specials data.
+ * Returns schema Offer data for Special posts.
  *
  * @since 10.2
  */
@@ -23,20 +23,18 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 	}
 
 	/**
-	 * Returns Specials data.
+	 * Returns Offer data.
 	 *
-	 * @return array $data Specials data.
+	 * @return array $data Offer data.
 	 */
 	public function generate() {
-		$tour_list  = get_post_meta( get_the_ID(), 'tour_to_special', false );
-		$accom_list = get_post_meta( get_the_ID(), 'accommodation_to_special', false );
+		$tour_list  = get_post_meta( $this->context->id, 'tour_to_special', false );
+		$accom_list = get_post_meta( $this->context->id, 'accommodation_to_special', false );
 		$data       = array(
-			'@type'            => array(
-				'Offer',
-			),
-			'@id'              => $this->context->canonical . '#special',
-			'name'             => $this->post->post_title,
-			'description'      => wp_strip_all_tags( $this->post->post_content ),
+			'@type'            => 'Offer',
+			'@id'              => $this->context->canonical . '#/schema/offer/' . $this->post->ID,
+			'name'             => get_the_title( $this->post->ID ),
+			'description'      => wp_strip_all_tags( apply_filters( 'the_content', $this->post->post_content ) ),
 			'url'              => $this->post_url,
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
@@ -47,17 +45,37 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 			$data['offeredBy'] = $this->context->site_represents_reference;
 		}
 
-		$data = $this->add_custom_field( $data, 'availabilityStarts', 'booking_validity_start' );
-		$data = $this->add_custom_field( $data, 'availabilityEnds', 'booking_validity_end' );
-		$data = $this->add_custom_field( $data, 'priceValidUntil', 'booking_validity_end' );
-		$data = $this->add_custom_field( $data, 'priceValidUntil', 'booking_validity_end' );
+		$data = $this->add_availability( $data, 'availabilityStarts', 'booking_validity_start' );
+		$data = $this->add_availability( $data, 'availabilityEnds', 'booking_validity_end' );
+		$data = $this->add_availability( $data, 'priceValidUntil', 'booking_validity_end' );
 		$data = $this->get_price( $data );
-
-		$data['itemOffered'] = \lsx\legacy\Schema_Utils::get_item_reviewed( $tour_list, 'Product' );
-		$data['itemOffered'] = \lsx\legacy\Schema_Utils::get_item_reviewed( $accom_list, 'Product' );
+		$data = $this->add_items_offered( $data, $tour_list, $accom_list );
 
 		$data = $this->add_articles( $data );
 		$data = \lsx\legacy\Schema_Utils::add_image( $data, $this->context );
+
+		return $data;
+	}
+
+	/**
+	 * Adds a date-based field as an ISO 8601 date, converting the stored
+	 * CMB2 date field value.
+	 *
+	 * @param array  $data     Offer data.
+	 * @param string $data_key The schema property to set.
+	 * @param string $meta_key The meta key to read the raw date from.
+	 * @return array $data Offer data.
+	 */
+	public function add_availability( $data, $data_key, $meta_key ) {
+		$raw = get_post_meta( $this->context->id, $meta_key, true );
+		if ( false === $raw || '' === $raw ) {
+			return $data;
+		}
+
+		$timestamp = is_numeric( $raw ) ? (int) $raw : strtotime( $raw );
+		if ( false !== $timestamp && $timestamp > 0 ) {
+			$data[ $data_key ] = gmdate( 'Y-m-d', $timestamp );
+		}
 
 		return $data;
 	}
@@ -78,16 +96,43 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 			}
 		}
 		if ( false !== $price && '' !== $price ) {
-			$data['price']         = $price;
+			$numeric_price         = preg_replace( '/[^\d.]/', '', $price );
+			$data['price']         = '' !== $numeric_price ? $numeric_price : $price;
 			$data['priceCurrency'] = $currency;
 			$data['category']      = __( 'Special', 'to-specials' );
 			$data['availability']  = 'https://schema.org/LimitedAvailability';
 
 			$price_type = get_post_meta( $this->context->id, 'price_type', true );
 			if ( false !== $price_type && '' !== $price_type && 'none' !== $price_type ) {
-				$data['PriceSpecification'] = lsx_to_get_price_type_label( $price_type );
+				$data['priceSpecification'] = array(
+					'@type'         => 'PriceSpecification',
+					'price'         => '' !== $numeric_price ? $numeric_price : $price,
+					'priceCurrency' => $currency,
+					'unitText'      => lsx_to_get_price_type_label( $price_type ),
+				);
 			}
 		}
+		return $data;
+	}
+
+	/**
+	 * Merges the related tour and accommodation posts into a single
+	 * itemOffered value, typed appropriately, without overwriting each other.
+	 *
+	 * @param array $data       Offer data.
+	 * @param array $tour_list  Related tour post IDs.
+	 * @param array $accom_list Related accommodation post IDs.
+	 * @return array $data Offer data.
+	 */
+	public function add_items_offered( $data, $tour_list, $accom_list ) {
+		$items_offered = array();
+		$items_offered = array_merge( $items_offered, \lsx\legacy\Schema_Utils::get_item_reviewed( $tour_list, 'TouristTrip' ) );
+		$items_offered = array_merge( $items_offered, \lsx\legacy\Schema_Utils::get_item_reviewed( $accom_list, 'LodgingBusiness' ) );
+
+		if ( ! empty( $items_offered ) ) {
+			$data['itemOffered'] = 1 === count( $items_offered ) ? $items_offered[0] : $items_offered;
+		}
+
 		return $data;
 	}
 }

--- a/classes/class-to-specials-schema.php
+++ b/classes/class-to-specials-schema.php
@@ -34,7 +34,7 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 			'@type'            => 'Offer',
 			'@id'              => $this->context->canonical . '#/schema/offer/' . $this->post->ID,
 			'name'             => get_the_title( $this->post->ID ),
-			'description'      => wp_strip_all_tags( apply_filters( 'the_content', $this->post->post_content ) ),
+			'description'      => \lsx\schema\Helpers::strip_to_text( apply_filters( 'the_content', $this->post->post_content ) ),
 			'url'              => $this->post_url,
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,
@@ -67,14 +67,10 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 	 * @return array $data Offer data.
 	 */
 	public function add_availability( $data, $data_key, $meta_key ) {
-		$raw = get_post_meta( $this->context->id, $meta_key, true );
-		if ( false === $raw || '' === $raw ) {
-			return $data;
-		}
-
-		$timestamp = is_numeric( $raw ) ? (int) $raw : strtotime( $raw );
-		if ( false !== $timestamp && $timestamp > 0 ) {
-			$data[ $data_key ] = gmdate( 'Y-m-d', $timestamp );
+		$raw  = get_post_meta( $this->context->id, $meta_key, true );
+		$date = \lsx\schema\Helpers::format_iso_date( $raw );
+		if ( '' !== $date ) {
+			$data[ $data_key ] = $date;
 		}
 
 		return $data;
@@ -88,16 +84,11 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 	 */
 	public function get_price( $data ) {
 		$price         = get_post_meta( $this->context->id, 'price', true );
-		$currency      = 'USD';
-		$tour_operator = tour_operator();
-		if ( is_object( $tour_operator ) && isset( $tour_operator->options['general'] ) && is_array( $tour_operator->options['general'] ) ) {
-			if ( isset( $tour_operator->options['general']['currency'] ) && ! empty( $tour_operator->options['general']['currency'] ) ) {
-				$currency = $tour_operator->options['general']['currency'];
-			}
-		}
-		if ( false !== $price && '' !== $price ) {
-			$numeric_price         = preg_replace( '/[^\d.]/', '', $price );
-			$data['price']         = '' !== $numeric_price ? $numeric_price : $price;
+		$currency      = \lsx\schema\Helpers::get_currency();
+		$numeric_price = \lsx\schema\Helpers::normalise_price( $price );
+
+		if ( '' !== $numeric_price ) {
+			$data['price']         = $numeric_price;
 			$data['priceCurrency'] = $currency;
 			$data['category']      = __( 'Special', 'to-specials' );
 			$data['availability']  = 'https://schema.org/LimitedAvailability';
@@ -106,7 +97,7 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 			if ( false !== $price_type && '' !== $price_type && 'none' !== $price_type ) {
 				$data['priceSpecification'] = array(
 					'@type'         => 'PriceSpecification',
-					'price'         => '' !== $numeric_price ? $numeric_price : $price,
+					'price'         => $numeric_price,
 					'priceCurrency' => $currency,
 					'unitText'      => lsx_to_get_price_type_label( $price_type ),
 				);


### PR DESCRIPTION
## Summary

Aligns `class-to-specials-schema.php` with the approved Schema 2.0 mapping and shared helpers. All changes are confined to the single schema class.

## Changes

### Fixed
- **`@type`** simplified from `array( 'Offer' )` to a plain `'Offer'` string.
- **`@id`** updated from `#special` to `#/schema/offer/{id}` to avoid collisions on pages with multiple specials.
- **`name` / `description`** now use `get_the_title( $post->ID )` and `\lsx\schema\Helpers::strip_to_text()` on filtered content instead of raw `$post->post_title` / `wp_strip_all_tags()`.
- **Meta queries** changed from `get_the_ID()` to `$this->context->id` for consistency.
- **Duplicate `itemOffered` keys** — tours and accommodation were silently overwriting each other. Replaced with a new `add_items_offered()` method that merges both; tours typed as `TouristTrip`, accommodation as `LodgingBusiness`.
- **Duplicate `priceValidUntil`** assignment removed.
- **Availability / price-validity dates** now formatted as ISO 8601 via a new `add_availability()` helper using `\lsx\schema\Helpers::format_iso_date()`; fields omitted when the date is empty.
- **`get_price()` refactored** — currency resolved via `\lsx\schema\Helpers::get_currency()`; price normalised via `\lsx\schema\Helpers::normalise_price()`.
- **`priceSpecification` key casing** corrected (was `PriceSpecification`); now outputs a properly typed `PriceSpecification` object with `@type`, `price`, `priceCurrency`, and `unitText`.

### Added
- **`add_availability()`** — helper that reads a raw CMB2 date meta value, formats it as ISO 8601, and conditionally sets the given schema property.
- **`add_items_offered()`** — merges related tour and accommodation post IDs into a single `itemOffered` value without overwriting.

## Testing

- [ ] Special with both tour and accommodation — confirm single `itemOffered` array contains both.
- [ ] Special with no linked items — confirm `itemOffered` is absent.
- [ ] Booking validity dates — confirm `availabilityStarts`, `availabilityEnds`, and `priceValidUntil` output valid ISO 8601 dates.
- [ ] Special with no dates — confirm date fields are absent from output.
- [ ] `priceSpecification` — confirm it outputs as a `PriceSpecification` object with correct type and unit text.
- [ ] Validate output with Google Rich Results Test or Schema.org validator.

## Checklist

- [x] Changelog updated
- [x] No new dependencies introduced
- [x] Follows `\lsx\schema\Helpers` shared helper conventions