### PR TITLE
LS-1953: Address Plugin Check security and WPCS issues for TO Specials

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 === Tour Operator Special Offers ===
 Contributors: feedmymedia, lightspeedwp, eleshar, krugazul
 Donate link: https://lightspeedwp.agency/donate/
-Tags: lsx, tour operator, specials, accommodation, prices 
+Tags: lsx, tour operator, specials, accommodation, prices
 Requires at least: 6.7
-Tested up to: 6.9
+Tested up to: 7.0
 Requires PHP: 8.0
 Stable tag: 2.2
 License: GPLv3
@@ -34,7 +34,7 @@ We offer premium support for this plugin. Premium support that can be purchased 
 If you get stuck, you can ask for help in the [our Operator Specials plugin forum](https://touroperator.solutions/plugins/specials/).
 For help with premium add-ons from LightSpeed, use [our contact page](https://lightspeedwp.agency/contact-us/)
 
-= Will the Tour Operator Specials plugin work with my theme 
+= Will the Tour Operator Specials plugin work with my theme
 No; the Tour Operator Specials plugin will only work with LSX Theme.
 
 = Where can I report bugs or contribute to the project? =

--- a/classes/class-specials-schema.php
+++ b/classes/class-specials-schema.php
@@ -16,6 +16,10 @@
  * @author  LightSpeed
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class LSX_TO_Specials_Schema extends LSX_TO_Specials {
 
 	/**
@@ -45,7 +49,7 @@ class LSX_TO_Specials_Schema extends LSX_TO_Specials {
 		$price = get_post_meta( get_the_ID(), 'price', false );
 		$start_validity = get_post_meta( get_the_ID(), 'booking_validity_start', false );
 		$end_validity = get_post_meta( get_the_ID(), 'booking_validity_end', false );
-	
+
 
 		if ( ! empty( $destination_list_special ) ) {
 			foreach( $destination_list_special as $single_destination ) {

--- a/classes/class-to-specials-admin.php
+++ b/classes/class-to-specials-admin.php
@@ -16,6 +16,10 @@
  * @author  LightSpeed
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class LSX_TO_Specials_Admin extends LSX_TO_Specials {
 
 	/**

--- a/classes/class-to-specials-admin.php
+++ b/classes/class-to-specials-admin.php
@@ -35,7 +35,6 @@ class LSX_TO_Specials_Admin extends LSX_TO_Specials {
 	public function __construct() {
 		$this->set_vars();
 
-		add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 		add_action( 'init', array( $this, 'register_post_type' ), 100 );
 		add_filter( 'lsx_get_taxonomies_configs', array( $this, 'taxonomy_config' ), 10, 1 );
 		add_action( 'cmb2_admin_init', array( $this, 'register_cmb2_fields' ) );

--- a/classes/class-to-specials-frontend.php
+++ b/classes/class-to-specials-frontend.php
@@ -16,6 +16,10 @@
  * @author  LightSpeed
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 class LSX_TO_Specials_Frontend {
 
 	/**

--- a/classes/class-to-specials-frontend.php
+++ b/classes/class-to-specials-frontend.php
@@ -120,7 +120,7 @@ class LSX_TO_Specials_Frontend {
 	 */
 	public function terms_conditions_filter( $html = '', $meta_key = false, $value = false, $before = '', $after = '' ) {
 		if ( get_post_type() === 'special' && 'terms_conditions' === $meta_key ) {
-			$html = $before . '<div class="entry-content">' . apply_filters( 'the_content', wpautop( $value ) ) . '</div>' . $after;
+			$html = $before . '<div class="entry-content">' . apply_filters( 'the_content', wpautop( $value ) ) . '</div>' . $after; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 		}
 

--- a/classes/class-to-specials-schema.php
+++ b/classes/class-to-specials-schema.php
@@ -34,7 +34,7 @@ class LSX_TO_Specials_Schema extends LSX_TO_Schema_Graph_Piece {
 			'@type'            => 'Offer',
 			'@id'              => $this->context->canonical . '#/schema/offer/' . $this->post->ID,
 			'name'             => get_the_title( $this->post->ID ),
-			'description'      => \lsx\schema\Helpers::strip_to_text( apply_filters( 'the_content', $this->post->post_content ) ),
+			'description'      => \lsx\schema\Helpers::strip_to_text( apply_filters( 'the_content', $this->post->post_content ) ), // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			'url'              => $this->post_url,
 			'mainEntityOfPage' => array(
 				'@id' => $this->context->canonical . WPSEO_Schema_IDs::WEBPAGE_HASH,

--- a/classes/class-to-specials-templates.php
+++ b/classes/class-to-specials-templates.php
@@ -1,10 +1,14 @@
 <?php
 /**
  * Registers our Block Templates
- * 
+ *
  * @link https://github.com/lightspeedwp/lsx-starter-plugin/blob/master/classes/class-templates.php
  * @version 1.0.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class LSX_TO_Specials_Templates {
 

--- a/classes/class-to-specials.php
+++ b/classes/class-to-specials.php
@@ -63,8 +63,6 @@ if (!class_exists( 'LSX_TO_Specials' ) ) {
 			// Make TO last plugin to load
 			add_action( 'activated_plugin', array( $this, 'activated_plugin' ) );
 
-			add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
-
 			if ( false !== $this->post_types ) {
 				add_filter( 'lsx_to_framework_post_types', array( $this, 'post_types_filter' ) );
 				add_filter( 'lsx_to_post_types', array( $this, 'post_types_filter' ) );
@@ -96,13 +94,6 @@ if (!class_exists( 'LSX_TO_Specials' ) ) {
 		public function lsx_to_search_integration() {
 			add_filter( 'lsx_to_search_post_types', array( $this, 'post_types_filter' ) );
 			add_filter( 'lsx_to_search_taxonomies', array( $this, 'taxonomies_filter' ) );
-		}
-
-		/**
-		 * Load the plugin text domain for translation.
-		 */
-		public function load_plugin_textdomain() {
-			load_plugin_textdomain( 'to-specials' );
 		}
 
 		/**

--- a/classes/class-to-specials.php
+++ b/classes/class-to-specials.php
@@ -8,6 +8,11 @@
  * @link
  * @copyright 2018 LightSpeedDevelopment
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 if (!class_exists( 'LSX_TO_Specials' ) ) {
 	/**
 	 * Main plugin class.

--- a/includes/metaboxes/config-special.php
+++ b/includes/metaboxes/config-special.php
@@ -8,6 +8,11 @@
  * @link
  * @copyright 2017 LightSpeedDevelopment
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 $metabox = array(
 	'title'  => esc_html__( 'Tour Operator Plugin', 'to-specials' ),

--- a/includes/post-types/config-special.php
+++ b/includes/post-types/config-special.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $post_type = array(
 	'class'               => 'LSX_TO_Specials',
 	'menu_icon'           => 'dashicons-star-filled',

--- a/includes/taxonomies/config-special-type.php
+++ b/includes/taxonomies/config-special-type.php
@@ -9,6 +9,10 @@
  * @copyright 2017 LightSpeedDevelopment
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 $taxonomy = array(
 	'object_types'  => 'special',
 	'menu_position' => 73,

--- a/includes/template-tags.php
+++ b/includes/template-tags.php
@@ -6,6 +6,10 @@
  * @license GPL-3.0+
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Outputs the terms and conditions.
  *

--- a/patterns/special-card.php
+++ b/patterns/special-card.php
@@ -12,6 +12,10 @@
  * @version    2.2.0
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // phpcs:ignoreFile PluginCheck.CodeAnalysis.ImageFunctions.NonEnqueuedImage
 
 return array(


### PR DESCRIPTION
## Summary

Resolves all security and WPCS errors flagged by the WordPress Plugin Check (PCP) tool in preparation for WordPress.org submission. [LS-1953](https://linear.app/lightspeedwp/issue/LS-1953/address-plugin-check-security-and-wpcs-issues-for-to-specials).

## Changes

### Added
- **Direct file access protection** — `if ( ! defined( 'ABSPATH' ) ) { exit; }` guard added to all 10 PHP files missing it: `class-specials-schema.php`, `class-to-specials-admin.php`, `class-to-specials-frontend.php`, `class-to-specials-templates.php`, `class-to-specials.php`, `includes/metaboxes/config-special.php`, `includes/post-types/config-special.php`, `includes/taxonomies/config-special-type.php`, `includes/template-tags.php`, `patterns/special-card.php`.

### Updated
- **`README.txt`** — `Tested up to` bumped from `6.9` → `7.0` to meet the WordPress.org minimum requirement for search visibility.

### Removed
- **`load_plugin_textdomain()`** — removed the method and both `add_action( 'init', ... )` registrations (in `class-to-specials.php` and `class-to-specials-admin.php`); WordPress.org auto-loads translations since WP 4.6.

### Fixed
- **`NonPrefixedHooknameFound`** warnings for `apply_filters( 'the_content', ... )` in `class-to-specials-frontend.php` and `class-to-specials-schema.php` — suppressed with `// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound` as these are legitimate calls to a WordPress core filter, not custom hooks.

## Testing

- [ ] Plugin activates without PHP errors.
- [ ] Plugin Check (PCP) reports no remaining security or WPCS errors scoped to plugin code.
- [ ] Translation strings still load correctly on a site with a non-English locale.
- [ ] `terms_conditions` field on a Special post renders content correctly (validates `the_content` filter still fires).
- [ ] Schema output for a Special post includes a populated `description` field.

## Checklist

- [x] All 10 PHP files have ABSPATH protection
- [x] `load_plugin_textdomain` fully removed (method + both action registrations)
- [x] `phpcs:ignore` comments scoped to the specific sniff, not file-wide
- [x] `README.txt` tested-up-to header meets WordPress.org requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection against direct access to plugin files outside WordPress.
  * Strengthened safeguards across special listings, templates, settings, and taxonomy features.

* **Compatibility**
  * Updated plugin documentation to indicate testing with WordPress 7.0.

* **Documentation**
  * Cleaned up plugin metadata and FAQ formatting for improved readability.

* **Maintenance**
  * Updated internal coding standards and streamlined translation handling without changing displayed special content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->